### PR TITLE
feat(scope-override): stamp the CloudWatch logging annotations here

### DIFF
--- a/custom-scope-override/deployment/setup_logs_provider
+++ b/custom-scope-override/deployment/setup_logs_provider
@@ -116,17 +116,72 @@ fi
 
 echo "Routing application logs to: $PROVIDER (annotation prefix: $PREFIX)"
 
+# --- naming: where CloudWatch logs land ------------------------------------------
+# The scope template used to stamp these four as literals, so every account got the
+# same log group and the same 7-day retention with no way to change either. They live
+# here now, alongside the gates, because both are the same concern: this script owns
+# what the logs controller reads.
+#
+# Each value is rendered against the deployment context, so a value can derive from it
+# the way the defaults do — that is what makes `{{ .namespace.slug }}.{{ .application.slug }}`
+# work as a configurable value rather than a fixed string.
+#
+# `${type}`, `${instance}` and `${container}` are NOT rendered here on purpose: the
+# controller's Lua resolves those per record, at runtime. gomplate leaves `$` alone, so
+# one value can carry both layers, which is what the stream pattern has always done.
+# An explicitly empty value means "do not stamp this annotation", which is why each one
+# is tested with ${VAR+set} rather than :- — an unset variable takes the default, an
+# empty one suppresses the key.
+LOGS_NAMING_ANNOTATIONS='{}'
+if [ "$PROVIDER" = "cloudwatch" ]; then
+    add_naming_annotation() {
+        local key="$1" var_name="$2" default_value="$3" value rendered
+
+        if [ -n "${!var_name+set}" ]; then
+            value="${!var_name}"
+        else
+            value="$default_value"
+        fi
+
+        [ -z "$value" ] && return 0
+
+        # Rendered here and not inside the jq call below: `exit` from a command
+        # substitution only leaves the subshell, so a failed render would print its
+        # error and then stamp an empty value — a wrong destination, silently. A typo
+        # in an operator's pattern has to break the deployment instead.
+        if ! rendered=$(printf '%s' "$CONTEXT" | gomplate -c .=stdin:///context.json -i "$value" 2>&1); then
+            echo "ERROR: could not render logs annotation '$key' from '$value': $rendered" >&2
+            exit 1
+        fi
+
+        LOGS_NAMING_ANNOTATIONS=$(echo "$LOGS_NAMING_ANNOTATIONS" | jq -c \
+          --arg k "nullplatform.logs.cloudwatch.$key" \
+          --arg v "$rendered" '. + {($k): $v}')
+    }
+
+    add_naming_annotation log_group_name LOGS_CLOUDWATCH_LOG_GROUP_NAME \
+        '{{ .namespace.slug }}.{{ .application.slug }}'
+    add_naming_annotation log_stream_log_retention_days LOGS_CLOUDWATCH_LOG_RETENTION_DAYS \
+        '7'
+    add_naming_annotation log_stream_name_pattern LOGS_CLOUDWATCH_LOG_STREAM_NAME_PATTERN \
+        'type=${type};application={{ .application.id }};scope={{ .scope.id }};deploy={{ .deployment.id }};instance=${instance};container=${container}'
+    add_naming_annotation region LOGS_CLOUDWATCH_REGION \
+        '{{ .region }}'
+fi
+
 # --- inject ----------------------------------------------------------------------
-# Every gate this pod could be read on, stated explicitly either way.
+# Every gate this pod could be read on, stated explicitly either way, plus the naming
+# for the destination it was routed to.
 LOGS_ANNOTATIONS=$(jq -nc \
   --arg prefix "$PREFIX" \
   --arg default_prefix "$DEFAULT_PREFIX" \
-  --arg provider "$PROVIDER" '
+  --arg provider "$PROVIDER" \
+  --argjson naming "$LOGS_NAMING_ANNOTATIONS" '
     def gates($p): {
       "\($p).cloudwatch": (if $provider == "cloudwatch" then "true" else "false" end),
       "\($p).datadog":    (if $provider == "datadog"    then "true" else "false" end)
     };
-    gates($prefix) + (if $prefix == $default_prefix then {} else gates($default_prefix) end)
+    gates($prefix) + (if $prefix == $default_prefix then {} else gates($default_prefix) end) + $naming
 ')
 
 MODIFIERS=$(echo "$CONTEXT" | jq .k8s_modifiers)
@@ -135,5 +190,5 @@ MODIFIERS=$(echo "$MODIFIERS" | jq --argjson logs_annotations "$LOGS_ANNOTATIONS
 ')
 CONTEXT=$(echo "$CONTEXT" | jq --argjson modifiers "$MODIFIERS" '.k8s_modifiers = $modifiers')
 
-echo "Logs gate annotations set on k8s_modifiers.deployment.annotations:"
+echo "Logs annotations set on k8s_modifiers.deployment.annotations:"
 echo "$LOGS_ANNOTATIONS" | jq -r 'to_entries[] | "  \(.key): \(.value)"'

--- a/custom-scope-override/values.yaml
+++ b/custom-scope-override/values.yaml
@@ -4,11 +4,28 @@ configuration:
   # which the base chart exposes as cloudwatch.logs.annotation and
   # logging.datadog.logsAnnotation. Only change this together with the cluster.
   #
-  # This cluster's controller reads nullplatform.logs.spin.*, so the templates have to
-  # stamp that family or the gate never matches and the logs are dropped silently. The
-  # scope templates also keep stamping the default family while this is not
-  # "nullplatform.logs", so the two sides can move in either order.
+  # This cluster's controller reads nullplatform.logs.spin.*, so setup_logs_provider has
+  # to stamp that family or the gate never matches and the logs are dropped silently.
+  #
+  # The scope template stamps NO gate of its own any more, so this is the only thing that
+  # gates: a pod that setup_logs_provider leaves untouched — a scope that delegates on an
+  # org with no logging provider configured — ships nowhere.
   LOGS_ANNOTATION_PREFIX: "nullplatform.logs.spin"
+  # Values of the CloudWatch logging annotations the scope template stamps: where the
+  # logs land once something routes them there. A separate concern from the prefix
+  # above, which is about whether they are routed at all.
+  #
+  # Each value is rendered against the deployment context, so it can be a pattern the
+  # way the defaults are. `${type}`, `${instance}` and `${container}` are NOT rendered
+  # at deploy time — the logs controller resolves those per record. An empty value
+  # stamps no annotation at all.
+  #
+  # Left commented: these are the defaults the scope template already applies, and
+  # setting them here would duplicate values that then drift. Uncomment to override.
+  # LOGS_CLOUDWATCH_LOG_GROUP_NAME: "{{ .namespace.slug }}.{{ .application.slug }}"
+  # LOGS_CLOUDWATCH_LOG_RETENTION_DAYS: "7"
+  # LOGS_CLOUDWATCH_LOG_STREAM_NAME_PATTERN: "type=${type};application={{ .application.id }};scope={{ .scope.id }};deploy={{ .deployment.id }};instance=${instance};container=${container}"
+  # LOGS_CLOUDWATCH_REGION: "{{ .region }}"
   $: "$" # this is necessary to expand the expression $$ to $
   LINK_SPECIFICATION_ID: b229c8c8-101a-4dab-b0b0-7aa2e23d1bc1
   RECOVERY_SCOPE_SUFFIX: "recovery"


### PR DESCRIPTION
Pairs with nullplatform/scopes#224, which removes these annotations from the scope templates.

## What

`setup_logs_provider` already stamps the routing gates through `k8s_modifiers.deployment.annotations`. It now stamps the CloudWatch naming annotations through the same channel:

| Variable | Default |
|---|---|
| `LOGS_CLOUDWATCH_LOG_GROUP_NAME` | `{{ .namespace.slug }}.{{ .application.slug }}` |
| `LOGS_CLOUDWATCH_LOG_RETENTION_DAYS` | `7` |
| `LOGS_CLOUDWATCH_LOG_STREAM_NAME_PATTERN` | `type=${type};application={{ .application.id }};scope={{ .scope.id }};deploy={{ .deployment.id }};instance=${instance};container=${container}` |
| `LOGS_CLOUDWATCH_REGION` | `{{ .region }}` |

Each default is the expression the scope template carried, so behaviour is unchanged until someone sets one.

## Why here and not in scopes

All of these are inputs to the same consumer, the logs controller. Making the gate configurable in one repo and the naming in another means two sources for one decision, and they can then disagree — a gate pointing at one annotation family while the naming points elsewhere ships logs to the wrong place, or nowhere, with no error. One owner keeps that impossible.

## Values may be patterns

Rendered against the deployment context, so a customized value derives from it the same way the defaults do:

```yaml
LOGS_CLOUDWATCH_LOG_GROUP_NAME: "{{ .account.slug }}-{{ .namespace.slug }}"
```

`${type}`, `${instance}` and `${container}` are **not** rendered here: the controller's Lua resolves those per record. gomplate leaves `$` alone, so a single value carries both substitution layers — which is what the stream pattern has always done.

An empty value omits its annotation, tested with `${VAR+set}` rather than `:-` so that an unset variable takes the default while an explicitly empty one suppresses the key.

Only stamped when the resolved provider is `cloudwatch`; the keys mean nothing for Datadog.

## Failure handling

A value that fails to render exits non-zero instead of stamping a partial result. Worth noting why the render does not sit inside the `jq` call: `exit` from a command substitution only leaves the subshell, so a bad pattern would print its error and then stamp an empty log group anyway — logs delivered to `fallback_log_group` with nothing in any log to say why. Caught while testing the failure path, not the happy one.

## Verification

| Case | Result |
|---|---|
| provider `cloudwatch` | 4 gates + 4 naming = 8 annotations |
| provider `datadog` | 4 gates, no CloudWatch naming |
| `LOGS_CLOUDWATCH_REGION=''` | omits only that one (7) |
| all four empty | gates only (4) |
| `{{ .account.slug }}-{{ .namespace.slug }}` | renders `acct-nsps` |
| `${type}` / `${instance}` / `${container}` | survive literally |
| pattern with a missing context key | `exit 1`, nothing stamped |

End to end through the real scope template from nullplatform/scopes#224: the pod ends up with the four `nullplatform.logs.cloudwatch.*` values **identical** to what the template used to produce, plus the resolved gates.

## Note on rollout

With scopes#224 merged, a pod only ships logs if this script stamps a gate. A scope that delegates on an org with no logging provider configured is left untouched by design, so those pods ship nowhere. If a gradual path is wanted, this script defaulting to CloudWatch when it finds no provider is the place for it.
